### PR TITLE
Fix eslint errors

### DIFF
--- a/barcodeFrontend/app/remote-connection/page.tsx
+++ b/barcodeFrontend/app/remote-connection/page.tsx
@@ -27,7 +27,7 @@ export default function RemoteConnectionPage() {
             <li><strong>Simplified Integration:</strong> Access powerful barcode functionalities through a simple HTTP API.</li>
             <li><strong>Scalability:</strong> Rely on our robust infrastructure to handle your requests, from small projects to enterprise-level applications.</li>
             <li><strong>Cross-Platform Compatibility:</strong> Connect from any platform or programming language that supports HTTP requests.</li>
-            <li><strong>Focus on Your Core Logic:</strong> Offload complex barcode processing to our specialized servers and focus on your application's unique features.</li>
+            <li><strong>Focus on Your Core Logic:</strong> Offload complex barcode processing to our specialized servers and focus on your application&apos;s unique features.</li>
           </ul>
         </section>
 
@@ -36,7 +36,7 @@ export default function RemoteConnectionPage() {
             Connecting with C# (Visual Studio)
           </h2>
           <p className="text-md md:text-lg leading-relaxed mb-6">
-            This section provides a step-by-step guide to connect to `thebarcodeapi.com` using C# in Visual Studio. We'll demonstrate how to make a POST request to generate a barcode.
+            This section provides a step-by-step guide to connect to `thebarcodeapi.com` using C# in Visual Studio. We&apos;ll demonstrate how to make a POST request to generate a barcode.
           </p>
           
           <h3 className="text-xl md:text-2xl font-medium mb-4 text-[var(--accent-color)]/80">Prerequisites</h3>
@@ -45,7 +45,7 @@ export default function RemoteConnectionPage() {
             <li>Visual Studio IDE.</li>
             <li>A basic understanding of C# and asynchronous programming.</li>
             <li>For older .NET Framework versions, you might need to install `Newtonsoft.Json` via NuGet for JSON handling. For .NET Core and .NET 5+, `System.Text.Json` is built-in. We will use `System.Net.Http.Json` for simplicity in this example, which is available in modern .NET versions.</li>
-            <li>Your API Key from theBarcodeAPI.com (replace `"YOUR_API_KEY"` in the code).</li>
+            <li>Your API Key from theBarcodeAPI.com (replace &quot;YOUR_API_KEY&quot; in the code).</li>
           </ul>
 
           <h3 className="text-xl md:text-2xl font-medium mb-4 text-[var(--accent-color)]/80">Step-by-Step Guide</h3>
@@ -151,7 +151,7 @@ public class BarcodeGenerator
               </code>
             </pre>
             <p className="mt-4 text-xs md:text-sm text-slate-400 dark:text-slate-500">
-              Remember to replace `"YOUR_API_KEY"` with your actual key. The code includes options for handling JSON responses (e.g., an image URL) or direct image data. Adjust the `Accept` header and response processing accordingly.
+              Remember to replace &quot;YOUR_API_KEY&quot; with your actual key. The code includes options for handling JSON responses (e.g., an image URL) or direct image data. Adjust the `Accept` header and response processing accordingly.
             </p>
           </div>
         </section>
@@ -161,23 +161,23 @@ public class BarcodeGenerator
             Connecting with Python
           </h2>
           <p className="text-md md:text-lg leading-relaxed mb-6">
-            This section demonstrates how to connect to `thebarcodeapi.com` using a Python script. We'll use the popular `requests` library to make a POST request for barcode generation.
+            This section demonstrates how to connect to `thebarcodeapi.com` using a Python script. We&apos;ll use the popular `requests` library to make a POST request for barcode generation.
           </p>
 
           <h3 className="text-xl md:text-2xl font-medium mb-4 text-[var(--accent-color)]/80">Prerequisites</h3>
           <ul className="list-disc list-inside mb-6 space-y-1">
             <li>Python 3.6+ installed.</li>
             <li>The `requests` library. You can install it using pip: <code className="bg-black/20 dark:bg-black/30 p-1 rounded text-xs text-[var(--accent-color)]">pip install requests</code>.</li>
-            <li>Your API Key from theBarcodeAPI.com (replace `"YOUR_API_KEY"` in the code).</li>
+            <li>Your API Key from theBarcodeAPI.com (replace &quot;YOUR_API_KEY&quot; in the code).</li>
           </ul>
 
           <h3 className="text-xl md:text-2xl font-medium mb-4 text-[var(--accent-color)]/80">Step-by-Step Guide</h3>
           <ol className="list-decimal list-inside space-y-3 mb-6">
-            <li><strong>Install `requests`:</strong> If you haven't already, open your terminal or command prompt and run `pip install requests`.</li>
+            <li><strong>Install `requests`:</strong> If you haven&apos;t already, open your terminal or command prompt and run `pip install requests`.</li>
             <li><strong>Create a Python file:</strong> Create a new file (e.g., `barcode_request.py`).</li>
             <li><strong>Write the Code:</strong> Copy and paste the Python code snippet below into your file.</li>
             <li><strong>Replace API Key:</strong> Update the `api_key` variable with your actual API key.</li>
-            <li><strong>Run the Script:</strong> Execute the script from your terminal: `python barcode_request.py`. It will send the request and print the server's response.</li>
+            <li><strong>Run the Script:</strong> Execute the script from your terminal: `python barcode_request.py`. It will send the request and print the server&apos;s response.</li>
           </ol>
           
           <div className="mt-6 bg-black/20 dark:bg-black/30 p-4 md:p-6 rounded-lg shadow-inner border border-white/10 dark:border-white/5">
@@ -251,7 +251,7 @@ if __name__ == "__main__":
               </code>
             </pre>
             <p className="mt-4 text-xs md:text-sm text-slate-400 dark:text-slate-500">
-              Ensure you replace `"YOUR_API_KEY"`. This script currently expects a JSON response. If the API is configured to send the image directly, you'll need to adjust the `Accept` header to something like `"image/png"` and modify the response handling to save `response.content` to a file.
+              Ensure you replace &quot;YOUR_API_KEY&quot;. This script currently expects a JSON response. If the API is configured to send the image directly, you&apos;ll need to adjust the `Accept` header to something like &quot;image/png&quot; and modify the response handling to save `response.content` to a file.
             </p>
           </div>
         </section>

--- a/barcodeFrontend/next-sitemap.config.js
+++ b/barcodeFrontend/next-sitemap.config.js
@@ -11,4 +11,15 @@ module.exports = {
       'https://www.thebarcodeapi.com/sitemap-0.xml',
     ],
   },
+  additionalPaths: async (config) => {
+    return [
+      {
+        loc: 'https://api.thebarcodeapi.com',
+        changefreq: 'daily',
+        priority: 0.7,
+        lastmod: new Date().toISOString(),
+      },
+      // Add other manual paths here if needed in the future
+    ];
+  },
 };

--- a/barcodeFrontend/package-lock.json
+++ b/barcodeFrontend/package-lock.json
@@ -8047,7 +8047,6 @@
       "version": "15.3.3",
       "resolved": "https://registry.npmjs.org/next/-/next-15.3.3.tgz",
       "integrity": "sha512-JqNj29hHNmCLtNvd090SyRbXJiivQ+58XjCcrC50Crb5g5u2zi7Y2YivbsEfzk6AtVI80akdOQbaMZwWB1Hthw==",
-      "license": "MIT",
       "dependencies": {
         "@next/env": "15.3.3",
         "@swc/counter": "0.1.3",

--- a/barcodeFrontend/public/sitemap-0.xml
+++ b/barcodeFrontend/public/sitemap-0.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://www.thebarcodeapi.com</loc><lastmod>2025-05-30T06:43:17.687Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.thebarcodeapi.com/bulk</loc><lastmod>2025-05-30T06:43:17.687Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.thebarcodeapi.com/support</loc><lastmod>2025-05-30T06:43:17.687Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.thebarcodeapi.com/bulk</loc><lastmod>2025-05-31T07:02:25.407Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.thebarcodeapi.com</loc><lastmod>2025-05-31T07:02:25.407Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.thebarcodeapi.com/remote-connection</loc><lastmod>2025-05-31T07:02:25.407Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.thebarcodeapi.com/support</loc><lastmod>2025-05-31T07:02:25.407Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/barcodeFrontend/public/sitemap-0.xml
+++ b/barcodeFrontend/public/sitemap-0.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://www.thebarcodeapi.com/bulk</loc><lastmod>2025-05-31T07:02:25.407Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.thebarcodeapi.com</loc><lastmod>2025-05-31T07:02:25.407Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.thebarcodeapi.com/remote-connection</loc><lastmod>2025-05-31T07:02:25.407Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.thebarcodeapi.com/support</loc><lastmod>2025-05-31T07:02:25.407Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.thebarcodeapi.com</loc><lastmod>2025-05-31T07:06:33.348Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.thebarcodeapi.com/support</loc><lastmod>2025-05-31T07:06:33.348Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.thebarcodeapi.com/bulk</loc><lastmod>2025-05-31T07:06:33.348Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.thebarcodeapi.com/remote-connection</loc><lastmod>2025-05-31T07:06:33.348Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://api.thebarcodeapi.com</loc><lastmod>2025-05-31T07:06:33.348Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
This pull request includes changes to improve text consistency, enhance sitemap configuration, and update dependencies. The most important changes involve standardizing text encoding for apostrophes and quotation marks, adding dynamic paths to the sitemap configuration, and updating the sitemap XML file with new paths.

### Text Consistency Improvements:
* [`barcodeFrontend/app/remote-connection/page.tsx`](diffhunk://#diff-de2428c42febb5d00cee6897458705e00d9cc3b98aa096a42c5f85138347a567L30-R30): Updated text encoding for apostrophes (`&apos;`) and quotation marks (`&quot;`) across multiple sections to ensure consistency and proper rendering in HTML. [[1]](diffhunk://#diff-de2428c42febb5d00cee6897458705e00d9cc3b98aa096a42c5f85138347a567L30-R30) [[2]](diffhunk://#diff-de2428c42febb5d00cee6897458705e00d9cc3b98aa096a42c5f85138347a567L39-R39) [[3]](diffhunk://#diff-de2428c42febb5d00cee6897458705e00d9cc3b98aa096a42c5f85138347a567L48-R48) [[4]](diffhunk://#diff-de2428c42febb5d00cee6897458705e00d9cc3b98aa096a42c5f85138347a567L154-R154) [[5]](diffhunk://#diff-de2428c42febb5d00cee6897458705e00d9cc3b98aa096a42c5f85138347a567L164-R180) [[6]](diffhunk://#diff-de2428c42febb5d00cee6897458705e00d9cc3b98aa096a42c5f85138347a567L254-R254)

### Sitemap Enhancements:
* [`barcodeFrontend/next-sitemap.config.js`](diffhunk://#diff-64fb7a07850b8b29a56a7610a4c53ad5b60b9511d2993857146597fe1a432982R14-R24): Added an `additionalPaths` function to dynamically include manual paths, such as `https://api.thebarcodeapi.com`, with metadata like `changefreq`, `priority`, and `lastmod`.
* [`barcodeFrontend/public/sitemap-0.xml`](diffhunk://#diff-e520798ab812d1890affbf3452fe08d4c0bde6ccdf09ba16c95eedf53a0c7006L3-R7): Updated the sitemap XML file to include new paths (`https://api.thebarcodeapi.com` and `https://www.thebarcodeapi.com/remote-connection`) with updated timestamps.

### Dependency Update:
* [`barcodeFrontend/package-lock.json`](diffhunk://#diff-764ce6121fafc93625cade4a692284c6c988d3f3b27843ac1ed60bad7a1394b0L8050): Removed the `license` field for the `next` package, likely as part of dependency cleanup or updates.