### PR TITLE
API doc update

### DIFF
--- a/barcodeApi/app/main.py
+++ b/barcodeApi/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi_limiter import FastAPILimiter
 from pydantic import ValidationError
 from fastapi.openapi.utils import get_openapi
@@ -205,8 +205,8 @@ app = FastAPI(
     Rate limits apply based on authentication status and tier level.
     """,
     version=settings.API_VERSION,
-    docs_url="/redoc" if settings.ENVIRONMENT == "development" else None,
-    redoc_url="/docs",
+    docs_url="/swagger",
+    redoc_url="/",
     openapi_url="/openapi.json",
     lifespan=lifespan,
     root_path=settings.ROOT_PATH,
@@ -277,6 +277,10 @@ async def log_memory_usage():
         gc.collect()
         logger.debug(f"Garbage collection: {gc.get_count()}")
         await asyncio.sleep(60)
+
+@app.get("/docs", include_in_schema=False)
+async def redirect_docs_to_root():
+    return RedirectResponse(url="/", status_code=301)
 
 app.include_router(health.router)
 app.include_router(barcode.router)

--- a/barcodeFrontend/lib/config/site.ts
+++ b/barcodeFrontend/lib/config/site.ts
@@ -12,7 +12,7 @@ export const siteConfig = {
     { href: '/', label: 'Home' },
     { href: '/bulk', label: 'Bulk', longLabel: 'Bulk Generate' },
     { href: '/remote-connection', label: 'Remote API', longLabel: 'Remote Connection Guide', external: false },
-    { href: 'https://api.thebarcodeapi.com/docs', label: 'Docs', longLabel: 'API Documentation', target: '_blank' },
+    { href: 'https://api.thebarcodeapi.com/', label: 'Docs', longLabel: 'API Documentation', target: '_blank' },
     { href: '/support', label: 'Support' }
     ],
     social: [


### PR DESCRIPTION
This pull request includes changes to improve API documentation accessibility and update routing behavior in both the backend and frontend. The most important changes involve modifying documentation URLs, adding a redirect endpoint in the backend, and updating frontend links to match the new structure.

### Backend changes:

* [`barcodeApi/app/main.py`](diffhunk://#diff-ebacc3c766fb38f955470bef93b77bb70e581fb0712d57341da40d5d5d5923baL208-R209): Updated `docs_url` to `/swagger` and `redoc_url` to `/` in the `custom_openapi` function to streamline access to API documentation.
* [`barcodeApi/app/main.py`](diffhunk://#diff-ebacc3c766fb38f955470bef93b77bb70e581fb0712d57341da40d5d5d5923baR281-R284): Added a new endpoint `/docs` that redirects users to the root URL (`/`) using a `RedirectResponse`. This ensures backward compatibility for users accessing the previous documentation URL.

### Frontend changes:

* [`barcodeFrontend/lib/config/site.ts`](diffhunk://#diff-2b9ce19a74be3ad3baff5d0b735634c4ba41c9b0eb2a719f665761cde1bb890aL15-R15): Updated the `Docs` link in the site configuration to point to `https://api.thebarcodeapi.com/` instead of `https://api.thebarcodeapi.com/docs`, aligning with the new backend routing changes.