### PR TITLE
Fix: Resolve log volume permission errors for barcodeApi

### DIFF
--- a/barcodeApi/Dockerfile
+++ b/barcodeApi/Dockerfile
@@ -51,8 +51,8 @@ RUN dos2unix /app/start.sh && \
     chown -R appuser:appuser /app && \
     chmod -R 755 /app
 
-# Ensure /app/logs exists and is owned by appuser
-RUN mkdir -p /app/logs && chown -R appuser:appuser /app/logs
+# Ensure /app/logs exists
+RUN mkdir -p /app/logs
 
 # Switch to appuser user
 USER appuser

--- a/barcodeApi/start.sh
+++ b/barcodeApi/start.sh
@@ -43,7 +43,7 @@ if [ ! -f "/app/logs/app.log" ]; then
     touch /app/logs/app.log
 fi
 # chown -R appuser:appuser /app/logs
-chmod -R 775 /app/logs
+# chmod -R 775 /app/logs
 # Wait for the database to be ready
 print_header "Database Check"
 if check_db_connection; then


### PR DESCRIPTION
This pull request includes changes to the `barcodeApi` project, specifically in the `Dockerfile` and `start.sh` script, to simplify file permission management and improve clarity. The most important changes involve removing redundant ownership commands and commenting out unnecessary lines.

### Changes to file permission management:

* [`barcodeApi/Dockerfile`](diffhunk://#diff-2b9d59b11b49007a2bf7773f98b3721a56c3c2c464c99bb6f2ca435b6069c94bL54-R55): Removed the command to set ownership of `/app/logs` to `appuser`, as it is no longer necessary.
* [`barcodeApi/start.sh`](diffhunk://#diff-1b7831700438e7558a6ee808feb0f0c1d2d40af72ba295933eff763cef5b8f4cL46-R46): Commented out the `chmod -R 775 /app/logs` command to avoid redundant permission settings.