### PR TITLE
feat: Add animations and conditional visibility to scroll buttons

### DIFF
--- a/barcodeFrontend/app/remote-connection/page.tsx
+++ b/barcodeFrontend/app/remote-connection/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ScrollButtons } from '@/components/ui/ScrollButtons';
+
 export default function RemoteConnectionPage() {
   return (
     <div className="min-h-screen bg-[var(--background)] text-[var(--foreground)] p-4 md:p-8">
@@ -367,6 +369,7 @@ if __name__ == "__main__":
         }
 
       `}</style>
+      <ScrollButtons />
     </div>
   );
 }

--- a/barcodeFrontend/components/ui/ScrollButtons.tsx
+++ b/barcodeFrontend/components/ui/ScrollButtons.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+
+const ScrollButtons = () => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [showScrollToBottom, setShowScrollToBottom] = useState(true);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  const scrollToBottom = () => {
+    window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
+  };
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const currentScrollPos = window.pageYOffset || document.documentElement.scrollTop;
+      const atTop = currentScrollPos < 400;
+      // Ensure document.body is available
+      const atBottom = document.body ? (window.innerHeight + currentScrollPos) >= document.body.scrollHeight - 400 : false;
+
+      setIsVisible(!atTop);
+      setShowScrollToBottom(!atBottom);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    // Call handler once on mount to set initial state based on current scroll position
+    handleScroll();
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  return (
+    <div
+      className={`fixed bottom-4 right-4 flex flex-col space-y-2 transition-opacity duration-300 ease-in-out ${
+        isVisible ? "opacity-100" : "opacity-0 pointer-events-none"
+      }`}
+    >
+      {/* Scroll to Top button is always rendered when isVisible is true */}
+      <Button
+        onClick={scrollToTop}
+        variant="outline"
+        className="hover:scale-105 transform transition-transform duration-200"
+      >
+        Scroll to Top
+      </Button>
+
+      {/* Scroll to Bottom button is rendered if isVisible and showScrollToBottom are true */}
+      {showScrollToBottom && (
+        <Button
+          onClick={scrollToBottom}
+          variant="outline"
+          className="hover:scale-105 transform transition-transform duration-200"
+        >
+          Scroll to Bottom
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default ScrollButtons;


### PR DESCRIPTION
I enhanced the `ScrollButtons` component on the /remote-connection page with the following features:

- Buttons now appear with a fade-in transition only after you have scrolled down a certain threshold (400px).
- The "Scroll to Bottom" button is hidden when you are near the bottom of the page.
- Buttons fade out when they are not active (e.g., at the top of the page).
- I added a subtle scale-up hover effect to both buttons for improved user feedback.

These changes make the scroll buttons more dynamic and less intrusive, improving the overall user experience.