### PR TITLE
Fix: Improve code example styling and add copy buttons

### DIFF
--- a/barcodeFrontend/public/sitemap-0.xml
+++ b/barcodeFrontend/public/sitemap-0.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://www.thebarcodeapi.com/bulk</loc><lastmod>2025-06-03T03:30:42.048Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.thebarcodeapi.com</loc><lastmod>2025-06-03T03:30:42.049Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.thebarcodeapi.com/remote-connection</loc><lastmod>2025-06-03T03:30:42.049Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.thebarcodeapi.com/support</loc><lastmod>2025-06-03T03:30:42.049Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://api.thebarcodeapi.com</loc><lastmod>2025-06-03T03:30:42.049Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.thebarcodeapi.com/bulk</loc><lastmod>2025-06-03T03:43:09.103Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.thebarcodeapi.com</loc><lastmod>2025-06-03T03:43:09.103Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.thebarcodeapi.com/remote-connection</loc><lastmod>2025-06-03T03:43:09.103Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.thebarcodeapi.com/support</loc><lastmod>2025-06-03T03:43:09.103Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://api.thebarcodeapi.com</loc><lastmod>2025-06-03T03:43:09.103Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
This commit addresses your feedback regarding the remote connection page:

- Improves the visibility and contrast of code examples (MCP, C#, Python, JavaScript) by:
    - Changing the background of the overall code block container (`div`) to `bg-slate-200 dark:bg-slate-800`.
    - Giving the `<pre>` tag (containing the code) a lighter, distinct background (`bg-slate-100 dark:bg-slate-700`).
    - Updating code text color to `text-black dark:text-slate-200` for better readability on the new `<pre>` background.
    - Making headers (e.g., "C# Code Example") more prominent with fully opaque accent color text and bold font weight.
- Implements a "Copy to Clipboard" button for each code snippet:
    - Adds a "Copy Code" button next to each code example's header.
    - Clicking the button copies the respective code to the clipboard using `navigator.clipboard.writeText()`.
    - Provides you feedback by temporarily changing the button text to "Copied!" and disabling it.
    - Includes React state management for individual button feedback.

The frontend application builds successfully with these changes.