### PR TITLE
Fix: Configure PM2 for Next.js frontend stability

### DIFF
--- a/scripts/infra/templates/ecosystem.config.js.template
+++ b/scripts/infra/templates/ecosystem.config.js.template
@@ -12,21 +12,20 @@ module.exports = {
     },
     cwd: '/opt/thebarcodeapi/__ENVIRONMENT__/current',
     instances: 2,
-    exec_mode: 'fork',
+    exec_mode: 'cluster',
     autorestart: true,
     watch: false,
-    max_memory_restart: '512M',
+    max_memory_restart: '1024M',
     wait_ready: false,
     listen_timeout: 30000,
     kill_timeout: 5000,
     exp_backoff_restart_delay: 100,
     restart_delay: 2000,
-    max_restarts: 3,
+    max_restarts: 5,
     error_file: '/opt/thebarcodeapi/__ENVIRONMENT__/logs/err.log',
     out_file: '/opt/thebarcodeapi/__ENVIRONMENT__/logs/out.log',
     merge_logs: true,
-    min_uptime: '60s',
-    node_args: '--expose-gc',
-    increment_var: 'PORT'
+    min_uptime: '120s',
+    node_args: '--expose-gc'
   }]
 };


### PR DESCRIPTION
This pull request updates the PM2 configuration template in `ecosystem.config.js.template` to optimize application performance and reliability. Key changes include switching to a clustered execution mode, increasing memory and restart limits, and adjusting uptime settings.

### Performance and reliability improvements:

* Changed `exec_mode` from `'fork'` to `'cluster'` to enable clustering for better CPU utilization.
* Increased `max_memory_restart` from `'512M'` to `'1024M'` to allow higher memory usage before restarting.
* Increased `max_restarts` from `3` to `5` to allow more restart attempts in case of failures.
* Updated `min_uptime` from `'60s'` to `'120s'` to ensure processes run longer before being considered stable.

### Simplifications:

* Removed the `increment_var` property (`'PORT'`), as it is no longer needed.