### PR TITLE
Fix: Correct NEXT_PUBLIC_API_URL for frontend container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         - VERSION_ARG=${PROJECT_VERSION:-0.0.0-default}
         - PYTHON_ENV=${ENVIRONMENT:-production}
     ports:
-      - "${API_PORT:-8000}:8000" # Allow host port to be configured via .env
+      - "${API_PORT:-8000}:8000"
     depends_on:
       db:
         condition: service_healthy
@@ -55,10 +55,8 @@ services:
       # Next.js environment variables
       - NODE_ENV=production
       - PORT=3000
-      - NEXT_PUBLIC_API_URL=http://barcodeapi:${API_PORT:-8000} # Ensure this is prioritized
+      - NEXT_PUBLIC_API_URL=http://barcodeapi:${API_PORT:-8000}
       - NEXT_PUBLIC_APP_VERSION=${PROJECT_VERSION:-0.0.0-default}
-      # NEXT_PUBLIC_ENVIRONMENT is now set via .env file through envsubst
-      # NEXT_PUBLIC_PROJECT_VERSION is now set via .env file through envsubst
     volumes:
       - ./barcodeFrontend/logs:/app/logs
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,8 +55,10 @@ services:
       # Next.js environment variables
       - NODE_ENV=production
       - PORT=3000
-      - NEXT_PUBLIC_API_URL=http://barcodeapi:${API_PORT:-8000}
+      - NEXT_PUBLIC_API_URL=http://barcodeapi:${API_PORT:-8000} # Ensure this is prioritized
       - NEXT_PUBLIC_APP_VERSION=${PROJECT_VERSION:-0.0.0-default}
+      # NEXT_PUBLIC_ENVIRONMENT is now set via .env file through envsubst
+      # NEXT_PUBLIC_PROJECT_VERSION is now set via .env file through envsubst
     volumes:
       - ./barcodeFrontend/logs:/app/logs
     healthcheck:

--- a/scripts/infra/templates/frontend.env.template
+++ b/scripts/infra/templates/frontend.env.template
@@ -1,6 +1,5 @@
 # Frontend .env template for Docker deployment
 # Use ${VAR} syntax for all variables to allow envsubst substitution
 
-NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
 NEXT_PUBLIC_ENVIRONMENT=${ENVIRONMENT}
 NEXT_PUBLIC_PROJECT_VERSION=${PROJECT_VERSION}


### PR DESCRIPTION
This pull request includes updates to the environment variable handling for the frontend application in the Docker deployment setup. The most important changes involve prioritizing the `NEXT_PUBLIC_API_URL` variable and transitioning certain environment variables to be set via `.env` files using `envsubst`.

Environment variable updates:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L58-R61): Added a comment to prioritize the `NEXT_PUBLIC_API_URL` variable and noted that `NEXT_PUBLIC_ENVIRONMENT` and `NEXT_PUBLIC_PROJECT_VERSION` are now set via `.env` files using `envsubst`.
* [`scripts/infra/templates/frontend.env.template`](diffhunk://#diff-1fa541d7d01612d9a1ab094bba064ebc72c30b328e453cf97b32b1115ead27efL4): Removed the `NEXT_PUBLIC_API_URL` variable from the `.env` template since it is now handled directly in the Docker configuration.